### PR TITLE
feat: add support for IPFS API exposed in ipfs-companion context

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -1,13 +1,13 @@
 /* global jest, it, expect */
 const { composeBundlesRaw } = require('redux-bundler')
-const getIpfs = require('window.ipfs-fallback')
+const windowIpfsFallback = require('window.ipfs-fallback')
 const ipfsBundle = require('./index')
 
 jest.mock('window.ipfs-fallback')
 
-it('should initialise IPFS', (done) => {
-  const testIdentity = { hello: 'world' }
-  getIpfs.mockResolvedValue({
+it('should initialise IPFS API via window.ipfs-fallback', (done) => {
+  const testIdentity = { hello: 'window.ipfs-fallback' }
+  windowIpfsFallback.mockResolvedValue({
     id: jest.fn().mockResolvedValue(testIdentity)
   })
   const store = composeBundlesRaw(
@@ -18,6 +18,45 @@ it('should initialise IPFS', (done) => {
   store.subscribeToSelectors(['selectIpfsReady'], () => {
     expect(store.selectIpfsReady()).toBe(true)
     expect(store.selectIpfsIdentity()).toBe(testIdentity)
+    done()
+  })
+  store.doInitIpfs()
+})
+
+it('should initialise IPFS API by accessing it directly when running inside of ipfs-companion', (done) => {
+  const testWebExtIdentity = { hello: 'ipfsCompanion.ipfs' }
+  // browser.runtime.getBackgroundPage().ipfsCompanion.ipfs will be present
+  // only if page was loaded from a path that belongs to our browser extension
+  global.browser = {
+    get runtime () {
+      return {
+        getBackgroundPage: async function () {
+          return {
+            get ipfsCompanion () {
+              return {
+                get ipfs () {
+                  return {
+                    id: async function () {
+                      return testWebExtIdentity
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const store = composeBundlesRaw(
+    ipfsBundle()
+  )()
+
+  expect(store.selectIpfsReady()).toBe(false)
+  store.subscribeToSelectors(['selectIpfsReady'], () => {
+    expect(store.selectIpfsReady()).toBe(true)
+    expect(store.selectIpfsIdentity()).toBe(testWebExtIdentity)
     done()
   })
   store.doInitIpfs()


### PR DESCRIPTION
This PR adds a simple optimization of reusing IPFS API object that already exists in ipfs-companion, as initially suggested in https://github.com/ipfs-shipyard/ipfs-companion/issues/514

> **TL;DR** We want to embed and ship dapps with our browser extension, and accessing API object directly enables us to reach peek performance because we avoid overhead of serialization introduced by `window.ipfs`


Note: we could move this optimization to `window.ipfs-fallback` package instead, if it makes more sense. For now I assumed our end game is WebUI, so this package is closer to that.