### PR TITLE
fix: maintain failed state while restarting

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,23 +100,23 @@ module.exports = (opts = {}) => {
       state = state || defaultState
 
       if (type === 'IPFS_INIT_STARTED') {
-        return Object.assign({}, state, { failed: false, invalidAddress: false })
+        return Object.assign({}, state, { ready: false })
       }
 
       if (type === 'IPFS_INIT_FINISHED') {
-        return Object.assign({}, state, { ready: true, invalidAddress: false }, payload)
+        return Object.assign({}, state, { ready: true, failed: false }, payload)
       }
 
       if (type === 'IPFS_STOPPED') {
-        return Object.assign({}, state, { ready: false, failed: false, invalidAddress: false })
+        return Object.assign({}, state, { ready: false, failed: false })
       }
 
       if (type === 'IPFS_INIT_FAILED') {
-        return Object.assign({}, state, { ready: false, failed: true, invalidAddress: false })
+        return Object.assign({}, state, { ready: false, failed: true })
       }
 
       if (type === 'IPFS_API_ADDRESS_UPDATED') {
-        return Object.assign({}, state, { ready: false, apiAddress: payload, failed: false, invalidAddress: false })
+        return Object.assign({}, state, { apiAddress: payload, invalidAddress: false })
       }
 
       if (type === 'IPFS_API_ADDRESS_INVALID') {

--- a/index.test.js
+++ b/index.test.js
@@ -5,6 +5,26 @@ const nock = require('nock')
 
 const longTimeout = 50 * 1000
 
+describe('reducer', () => {
+  it('should preserve failed state during a restart', () => {
+    const store = composeBundlesRaw(
+      ipfsBundle()
+    )()
+    store.dispatch({ type: 'IPFS_INIT_STARTED' })
+    expect(store.selectIpfsInitFailed()).toBe(false)
+    expect(store.selectIpfsReady()).toBe(false)
+    store.dispatch({ type: 'IPFS_INIT_FAILED' })
+    expect(store.selectIpfsInitFailed()).toBe(true)
+    expect(store.selectIpfsReady()).toBe(false)
+    store.dispatch({ type: 'IPFS_INIT_STARTED' })
+    expect(store.selectIpfsInitFailed()).toBe(true)
+    expect(store.selectIpfsReady()).toBe(false)
+    store.dispatch({ type: 'IPFS_INIT_FINISHED' })
+    expect(store.selectIpfsInitFailed()).toBe(false)
+    expect(store.selectIpfsReady()).toBe(true)
+  })
+})
+
 describe('window.ipfs', () => {
   afterEach(() => {
     global.ipfs = undefined


### PR DESCRIPTION
This avoids flashing in the UI while we try to re-init ipfs

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>