### PR TITLE
fix: detect ipfs-companion in Chromium-based browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,9 +181,10 @@ async function tryWindow () {
   console.log('Trying window.ipfs')
 
   // Opportunistic optimizations when running from ipfs-companion (+ ipfs-desktop in future)
-  if (typeof browser === 'object') {
+  if (typeof chrome === 'object') {
     // Note: under some vendors getBackgroundPage() will return null if window is in incognito mode
-    const webExt = await browser.runtime.getBackgroundPage()
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1329304
+    const webExt = chrome.extension.getBackgroundPage()
     // If extension is ipfs-companion exposing IPFS API, use it directly for best performance
     if (webExt && webExt.ipfsCompanion && webExt.ipfsCompanion.ipfs) {
       const ipfs = webExt.ipfsCompanion.ipfs

--- a/index.test.js
+++ b/index.test.js
@@ -28,7 +28,7 @@ describe('reducer', () => {
 describe('window.ipfs', () => {
   afterEach(() => {
     global.ipfs = undefined
-    global.browser = undefined
+    global.chrome = undefined
   })
 
   it('Should fail to connect via window.ipfs when missing', (done) => {
@@ -73,13 +73,13 @@ describe('window.ipfs', () => {
       id: jest.fn().mockResolvedValue(testIdentity)
     }
 
-    // browser.runtime.getBackgroundPage().ipfsCompanion.ipfs will be present
+    // chrome.extension.getBackgroundPage().ipfsCompanion.ipfs will be present
     // only if page was loaded from a path that belongs to our browser extension
     const testWebExtIdentity = { hello: 'ipfsCompanion.ipfs' }
-    global.browser = {
-      get runtime () {
+    global.chrome = {
+      get extension () {
         return {
-          getBackgroundPage: async function () {
+          getBackgroundPage: function () {
             return {
               get ipfsCompanion () {
                 return {
@@ -108,10 +108,10 @@ describe('window.ipfs', () => {
       expect(store.selectIpfsIdentity()).toBe(testWebExtIdentity)
       expect(store.selectIpfsProvider()).toBe('window.ipfs')
       delete global.ipfs
-      global.browser = {
-        get runtime () {
+      global.chrome = {
+        get extension () {
           return {
-            getBackgroundPage: async function () {
+            getBackgroundPage: function () {
               return {
               }
             }
@@ -138,7 +138,7 @@ describe('js-ipfs-api', () => {
   afterEach(() => {
     nock.cleanAll()
     global.ipfs = undefined
-    global.browser = undefined
+    global.chrome = undefined
   })
 
   it('Should connect via js-ipfs-api when window.ipfs is not present', (done) => {
@@ -204,7 +204,7 @@ describe('js-ipfs-api', () => {
 
 describe('js-ipfs', () => {
   global.ipfs = undefined
-  global.browser = undefined
+  global.chrome = undefined
 
   it('Should connect via js-ipfs', (done) => {
     const store = composeBundlesRaw(
@@ -273,7 +273,7 @@ describe('miscellaneous', () => {
 
   beforeEach(() => {
     global.ipfs = undefined
-    global.browser = undefined
+    global.chrome = undefined
 
     nock('http://127.0.0.1:5001')
       .post('/api/v0/id?stream-channels=true')


### PR DESCRIPTION
(Chrome does not expose `browser` namespace, instead it uses `chrome` (fun fact: which does not support promises :upside_down_face:)

Firefox supports both so we switch to Chrome notation as the lowest common denominator supported by all vendors. 

(After this is merged & releases we need to bump dep version used by WebUI)