### PR TITLE
fix: ipfs connection test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const defaultOptions = {
   defaultApiAddress: '/ip4/127.0.0.1/tcp/5001',
   ipfsConnectionTest: (ipfs) => {
     // ipfs connection is working if can we fetch the empty directtory.
-    return ipfs.get('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+    return ipfs.files.get('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
   }
 }
 


### PR DESCRIPTION
`ipfs.get()` gets aliased to `ipfs.files.get()` in the HTTP API & CLI but not in the core. So when testing with a core instance it was breaking.