### PR TITLE
feat: allow urls with authentication

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,10 +186,6 @@ function isMultiaddress (addr) {
 }
 
 function isURL (addr) {
-  if (addr === null || addr === undefined || typeof addr === 'undefined') {
-    return false
-  }
-
   try {
     // eslint-disable-next-line
     new URL(addr)

--- a/src/js-ipfs-api/index.js
+++ b/src/js-ipfs-api/index.js
@@ -1,4 +1,5 @@
 const toMultiaddr = require('uri-to-multiaddr')
+const { isURL } = require('../utils')
 const provider = 'js-ipfs-api'
 
 // 1. Try user specified API address
@@ -41,13 +42,32 @@ async function tryApi ({ IpfsApi, apiAddress, defaultApiAddress, location, ipfsC
 
 // Helper to construct and test an api client. Returns an js-ipfs-api instance or null
 async function maybeApi ({ apiAddress, apiOpts, ipfsConnectionTest, IpfsApi }) {
+  const address = isURL(apiAddress) ? parseURL(apiAddress) : apiAddress
+
   try {
-    const ipfs = new IpfsApi(apiAddress, apiOpts)
+    const ipfs = new IpfsApi(address, apiOpts)
     await ipfsConnectionTest(ipfs)
     return { ipfs, provider, apiAddress }
   } catch (error) {
     console.log('Failed to connect to ipfs-api', apiAddress)
   }
+}
+
+function parseURL (addr) {
+  const url = new URL(addr)
+
+  const opts = {
+    host: url.hostname,
+    port: url.port,
+    protocol: url.protocol.slice(0, -1),
+    headers: {}
+  }
+
+  if (url.username) {
+    opts.headers.authorization = `Basic ${btoa(unescape(encodeURIComponent(url.username + ':' + url.password)))}`
+  }
+
+  return opts
 }
 
 module.exports = tryApi

--- a/src/js-ipfs-api/index.js
+++ b/src/js-ipfs-api/index.js
@@ -1,3 +1,4 @@
+/* eslint-env browser, webextensions */
 const toMultiaddr = require('uri-to-multiaddr')
 const { isURL } = require('../utils')
 const provider = 'js-ipfs-api'

--- a/src/js-ipfs-api/index.test.js
+++ b/src/js-ipfs-api/index.test.js
@@ -115,3 +115,41 @@ it('Should use the defaultApiAddress if location fails', async (done) => {
   expect(config.protocol).toEqual('http')
   done()
 })
+
+it('Should use the apiAddress (url)', async (done) => {
+  const opts = {
+    apiAddress: 'http://1.1.1.1:1111',
+    defaultApiAddress: '/ip4/127.0.0.1/tcp/5001',
+    location: new URL('http://localhost:5001'),
+    IpfsApi: IpfsApi,
+    ipfsConnectionTest: jest.fn().mockResolvedValueOnce(true)
+  }
+  const res = await tryApi(opts)
+  expect(res.apiAddress).toEqual(opts.apiAddress)
+  expect(res.provider).toEqual('js-ipfs-api')
+  expect(opts.ipfsConnectionTest.mock.calls.length).toBe(1)
+  const config = res.ipfs.getEndpointConfig()
+  expect(config.host).toEqual('1.1.1.1')
+  expect(config.port).toEqual('1111')
+  expect(config.protocol).toEqual('http')
+  done()
+})
+
+it('Should use the apiAddress (url with basic auth)', async (done) => {
+  const opts = {
+    apiAddress: 'http://user:pass@1.1.1.1:1111',
+    defaultApiAddress: '/ip4/127.0.0.1/tcp/5001',
+    location: new URL('http://localhost:5001'),
+    IpfsApi: IpfsApi,
+    ipfsConnectionTest: jest.fn().mockResolvedValueOnce(true)
+  }
+  const res = await tryApi(opts)
+  expect(res.apiAddress).toEqual(opts.apiAddress)
+  expect(res.provider).toEqual('js-ipfs-api')
+  expect(opts.ipfsConnectionTest.mock.calls.length).toBe(1)
+  const config = res.ipfs.getEndpointConfig()
+  expect(config.host).toEqual('1.1.1.1')
+  expect(config.port).toEqual('1111')
+  expect(config.protocol).toEqual('http')
+  done()
+})

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,10 +4,6 @@
 const multiaddr = require('multiaddr')
 
 function isMultiaddress (addr) {
-  if (addr === null || addr === undefined || typeof addr === 'undefined') {
-    return false
-  }
-
   try {
     multiaddr(addr)
     return true

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,10 @@
 const multiaddr = require('multiaddr')
 
 function isMultiaddress (addr) {
+  if (addr === null || addr === undefined || typeof addr === 'undefined') {
+    return false
+  }
+
   try {
     multiaddr(addr)
     return true

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,36 @@
+'use strict'
+/* eslint-env browser, webextensions */
+
+const multiaddr = require('multiaddr')
+
+function isMultiaddress (addr) {
+  if (addr === null || addr === undefined || typeof addr === 'undefined') {
+    return false
+  }
+
+  try {
+    multiaddr(addr)
+    return true
+  } catch (_) {
+    return false
+  }
+}
+
+function isURL (addr) {
+  if (addr === null || addr === undefined || typeof addr === 'undefined') {
+    return false
+  }
+
+  try {
+    // eslint-disable-next-line
+    new URL(addr)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+module.exports = {
+  isMultiaddress,
+  isURL
+}


### PR DESCRIPTION
This should fix https://github.com/ipfs-shipyard/ipfs-webui/issues/836 by allowing to pass custom URLs.

I was not able to try it due to some CORS configuration with Basic Auth I couldn't manage to get working right now. Will try later. @lidel could you take a look at this to see if it looks OK or even try it if you've got time?

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>