### PR TITLE
fix: remove selectIpfsIdentity selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,6 @@ Adds the following methods to the redux store.
 
 - `boolean` - Is the last API Address you tried to use invalid?
 
-#### `store.selectIpfsIdentity()`
-
-- `Object` - The last resolved value of `ipfs.id()`.
-
 #### `store.selectIpfsProvider()`
 
 - `string` - Can be `window.ipfs`, `js-ipfs-api` or `js-ipfs`.

--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,6 @@ module.exports = (opts) => {
 
     selectIpfsInitFailed: state => state.ipfs.failed,
 
-    selectIpfsIdentity: state => state.ipfs.identity,
-
     doInitIpfs: () => async (store) => {
       await getIpfs(opts, store)
     },


### PR DESCRIPTION
Closes #27. `identity` was not being set since `ipfs.id()` is never called. On Web UI we have implemented a workaround by just calling `ipfs.id()` ourselves.

I created this PR, but I'm also open to the possibility of implementing the functionality instead of removing the selector.

Wdyt @lidel @autonome?

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>